### PR TITLE
fix: remove rust-build.action (Docker container incompatible with macOS/Windows)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,61 +85,7 @@ jobs:
             echo "should-release=false" >> $GITHUB_OUTPUT
           fi
 
-  # Job 2: Build Rust binaries using rust-build action
-  build-binaries:
-    needs: version
-    if: needs.version.outputs.should-release == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: macos-latest
-            target: x86_64-apple-darwin
-          - platform: macos-latest
-            target: aarch64-apple-darwin
-          - platform: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - platform: windows-latest
-            target: x86_64-pc-windows-msvc
-
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build Rust binary
-        uses: rust-build/rust-build.action@v1.4.5
-        with:
-          RUSTTARGET: ${{ matrix.target }}
-          UPLOAD_MODE: none
-          WORKING_DIR: src-tauri
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Rename and organize binary
-        shell: bash
-        run: |
-          mkdir -p artifacts
-          cd src-tauri/target/${{ matrix.target }}/release
-          
-          if [ -f "todo-notes-tracker.exe" ]; then
-            cp "todo-notes-tracker.exe" ../../../../artifacts/todo-notes-tracker-${{ matrix.target }}.exe
-          elif [ -f "todo-notes-tracker" ]; then
-            cp "todo-notes-tracker" ../../../../artifacts/todo-notes-tracker-${{ matrix.target }}
-            chmod +x ../../../../artifacts/todo-notes-tracker-${{ matrix.target }}
-          fi
-          
-          echo "Generated artifacts:"
-          ls -la ../../../../artifacts/
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-${{ matrix.target }}
-          path: artifacts/*
-          retention-days: 30
-
-  # Job 3: Build Tauri bundles (platform-specific installers)
+  # Job 2: Build Tauri bundles (platform-specific installers)
   build-bundles:
     needs: version
     if: needs.version.outputs.should-release == 'true'
@@ -242,9 +188,9 @@ jobs:
           path: artifacts/*
           retention-days: 30
 
-  # Job 4: Create GitHub release with all artifacts
+  # Job 3: Create GitHub release with all artifacts
   create-release:
-    needs: [version, build-binaries, build-bundles]
+    needs: [version, build-bundles]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

The rust-build.action integration in PR #6 has a critical issue:

**rust-build.action is a Docker container action** → Only works on Linux runners

### Errors Encountered
- ❌ macOS builds: "Container action is only supported on Linux"  
- ❌ Windows builds: "Container action is only supported on Linux"
- ❌ Invalid input 'WORKING_DIR' (should be 'SRC_DIR')

### Impact
- 4 out of 4 build-binaries jobs failed
- build-bundles jobs continue to work correctly
- Release workflow partially blocked

## Solution

**Remove the build-binaries job entirely** - this is the right architectural decision because:

1. **No functional loss**: Tauri bundle builds already include the binaries
2. **Users need installers**: DMG, MSI, AppImage, DEB are what users actually download
3. **Simpler workflow**: Easier to maintain and understand
4. **Raw binaries rarely needed**: For Tauri apps, users want the installers, not standalone binaries

## Changes

- ✅ Removed build-binaries job using rust-build.action
- ✅ Updated create-release dependency to only require build-bundles
- ✅ Bundle builds continue to work on all platforms
- ✅ Full cross-platform support maintained

## Testing

- [x] Workflow syntax validated
- [x] Bundle builds confirmed working in release run #18297223470
- [x] All platforms supported (macOS x64/ARM64, Linux, Windows)
- [ ] Will verify complete release after merge

## Result

Workflow now uses a simpler architecture:
```
version → build-bundles (4 platforms, parallel) → create-release
```

Instead of the failed approach:
```
version → build-binaries (failed) → create-release
          build-bundles (working) ↗
```

This maintains all the parallel execution benefits while fixing the compatibility issue.

---

Fixes the release workflow introduced in PR #6.