### PR TITLE
fix: restore ubuntu-20.04 for GLIBC 2.31 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
             target: x86_64-apple-darwin
           - platform: macos-latest
             target: aarch64-apple-darwin
-          - platform: ubuntu-latest
+          - platform: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
@@ -118,11 +118,11 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies (Ubuntu)
-        if: matrix.platform == 'ubuntu-latest'
+        if: contains(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
+            libwebkit2gtk-4.0-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
@@ -155,7 +155,7 @@ jobs:
           ls -la artifacts/
 
       - name: Prepare bundle artifacts (Linux)
-        if: matrix.platform == 'ubuntu-latest'
+        if: contains(matrix.platform, 'ubuntu')
         run: |
           mkdir -p artifacts
           # Copy AppImage


### PR DESCRIPTION
## Problem

User reported GLIBC compatibility issue after installing from v1.2.1:
```
todo-notes-tracker: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.39' not found
```

This issue was **previously fixed** in commit 52dfd94 but was **accidentally reintroduced** during the workflow refactor in PR #7.

## Root Cause

When removing rust-build.action in PR #7, the Linux build platform was inadvertently changed:
- **Before fix (commit 52dfd94)**: `ubuntu-20.04` with `libwebkit2gtk-4.0-dev` → GLIBC 2.31
- **After PR #7**: `ubuntu-latest` with `libwebkit2gtk-4.1-dev` → GLIBC 2.39 ❌

## Impact

**GLIBC 2.39 requirement** makes the binary incompatible with:
- Ubuntu 20.04, 22.04 (most common LTS versions)
- Debian 11, 12
- CentOS/RHEL 8, 9
- Fedora < 40
- Most Linux systems from 2020-2024

## Solution

Restore the original fix from commit 52dfd94:

1. **Platform**: `ubuntu-latest` → `ubuntu-20.04`
2. **WebKit**: `libwebkit2gtk-4.1-dev` → `libwebkit2gtk-4.0-dev`
3. **Conditionals**: Use `contains(matrix.platform, 'ubuntu')` to match ubuntu-20.04

## Benefits

- ✅ GLIBC 2.31 compatible with systems from 2020+
- ✅ Works on Ubuntu 20.04+, Debian 11+, CentOS 8+, Fedora 32+
- ✅ `.cargo/config.toml` static linking flags already in place
- ✅ Much wider Linux compatibility

## Changes

```diff
- platform: ubuntu-latest
+ platform: ubuntu-20.04

- libwebkit2gtk-4.1-dev
+ libwebkit2gtk-4.0-dev

- if: matrix.platform == 'ubuntu-latest'
+ if: contains(matrix.platform, 'ubuntu')
```

## Testing

After merge, will need to:
- [ ] Bump version to v1.2.2
- [ ] Trigger release with fixed configuration
- [ ] Test binary on Ubuntu 20.04/22.04
- [ ] Verify GLIBC requirement is 2.31 not 2.39

## References

- Original fix: commit 52dfd94 (Oct 2, 2025)
- Issue introduced: PR #7 (rust-build.action removal)
- Related: .cargo/config.toml has static linking configuration

---

**Critical fix** - blocks Linux users from using the application.