### PR TITLE
fix: build only DEB in container (AppImage requires FUSE)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,14 +204,13 @@ jobs:
       - name: Build Tauri bundles
         run: |
           cd src-tauri
-          cargo tauri build --target ${{ matrix.target }}
+          # Only build DEB package in container (AppImage creation fails due to FUSE requirements)
+          cargo tauri build --target ${{ matrix.target }} --bundles deb
 
       - name: Prepare bundle artifacts (Linux)
         run: |
           mkdir -p artifacts
-          # Copy AppImage
-          find "src-tauri/target/${{ matrix.target }}/release/bundle/appimage" -name "*.AppImage" -exec cp {} artifacts/ \; 2>/dev/null || true
-          # Copy deb package
+          # Copy deb package (AppImage skipped in container due to FUSE limitations)
           find "src-tauri/target/${{ matrix.target }}/release/bundle/deb" -name "*.deb" -exec cp {} artifacts/ \; 2>/dev/null || true
           echo "Generated artifacts:"
           ls -la artifacts/


### PR DESCRIPTION
## Problem

Linux build failed in container with:
```
Error failed to bundle project: failed to run linuxdeploy
```

### Root Cause
AppImage creation tool (`linuxdeploy`) requires **FUSE** (Filesystem in Userspace), which is not available in Docker containers without privileged mode.

## Solution

Build **only DEB package** in the container environment.

```diff
- cargo tauri build --target ${{ matrix.target }}
+ cargo tauri build --target ${{ matrix.target }} --bundles deb
```

## Rationale

### Why DEB is Sufficient
- ✅ **Primary format** for Debian/Ubuntu users (largest Linux desktop base)
- ✅ **Package manager integration** (apt/dpkg)
- ✅ **Automatic updates** through package managers
- ✅ **No FUSE requirement** - works in containers
- ✅ **Better GLIBC control** (2.36 from Debian Bookworm)

### AppImage Trade-offs
- ❌ Requires FUSE (not available in containers)
- ❌ Would need privileged container (security risk)
- ❌ Less common for actual installations
- ⚠️  Mostly used for portable/testing scenarios

## Impact

**Before**: 
- macOS: DMG ✓
- Windows: MSI ✓  
- Linux: DEB ✓, AppImage ✓

**After**:
- macOS: DMG ✓
- Windows: MSI ✓
- Linux: DEB ✓, AppImage ❌ (container limitation)

## Alternative Approaches Considered

1. **Enable FUSE in container** - Requires privileged mode (security risk)
2. **Separate AppImage job** - Adds complexity, ubuntu-latest has GLIBC 2.39 issue
3. **Build AppImage natively** - Defeats purpose of container (GLIBC control)

## Testing

- [ ] Workflow completes without errors
- [ ] DEB package created successfully  
- [ ] DEB installs on Ubuntu/Debian
- [ ] Binary has correct GLIBC requirement (2.36)

## Migration Notes

Users who need AppImage can:
1. Install from DEB package
2. Build locally with `cargo tauri build`
3. Wait for future native AppImage build job (if needed)

Most Linux users prefer DEB packages anyway for system integration.

---

**Fixes**: Container build failure in PR #9