### PR TITLE
feat: Simplify calendar with todo count badges

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-notes-tracker"
-version = "1.3.1"
+version = "1.4.0"
 description = "A bullet journal style todo app with pomodoro timer"
 authors = ["djp928"]
 license = "MIT"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -256,6 +256,119 @@ async fn load_calendar_events(data_dir: String) -> Result<HashMap<String, Vec<St
     }
 }
 
+/// Migrate calendar events to todos (one-time migration).
+///
+/// This function performs a one-time migration of calendar events from the old
+/// calendar_events.json file to the new unified todo system. Each calendar event
+/// is converted to a todo item and added to the appropriate day's data file.
+///
+/// # Arguments
+/// * `data_dir` - Path to the app data directory
+///
+/// # Returns
+/// A success message indicating how many events were migrated, or an error message.
+///
+/// # Migration Process
+/// 1. Checks if calendar_events.json exists
+/// 2. Loads all calendar events
+/// 3. For each date with events:
+///    - Loads existing day data
+///    - Converts each event to a todo item
+///    - Prepends todos to preserve order
+///    - Saves updated day data
+/// 4. Backs up original file as calendar_events.json.backup
+/// 5. Removes original calendar_events.json
+///
+/// # Errors
+/// Returns an error if:
+/// - Date parsing fails
+/// - File operations fail
+/// - JSON serialization/deserialization fails
+#[tauri::command]
+async fn migrate_calendar_events_to_todos(data_dir: String) -> Result<String, String> {
+    let events_file = PathBuf::from(&data_dir).join("calendar_events.json");
+    
+    // Check if calendar_events.json exists
+    if !events_file.exists() {
+        return Ok("No calendar events file found - migration not needed".to_string());
+    }
+    
+    // Load calendar events
+    let file_content = fs::read_to_string(&events_file)
+        .map_err(|e| format!("Failed to read calendar events file: {}", e))?;
+    
+    let events: HashMap<String, Vec<String>> = serde_json::from_str(&file_content)
+        .map_err(|e| format!("Failed to parse calendar events: {}", e))?;
+    
+    if events.is_empty() {
+        // File exists but is empty - still back it up and remove it
+        let backup_file = PathBuf::from(&data_dir).join("calendar_events.json.backup");
+        fs::rename(&events_file, &backup_file)
+            .map_err(|e| format!("Failed to backup empty calendar events file: {}", e))?;
+        return Ok("Calendar events file was empty - backed up and removed".to_string());
+    }
+    
+    let mut migrated_count = 0;
+    let mut migrated_dates = Vec::new();
+    
+    // For each date with events
+    for (date_str, event_list) in events {
+        // Parse date
+        let date = NaiveDate::parse_from_str(&date_str, "%Y-%m-%d")
+            .map_err(|e| format!("Invalid date format in calendar events: {} - {}", date_str, e))?;
+        
+        // Load existing day data
+        let file_path = PathBuf::from(&data_dir).join(format!("{}.json", date.format("%Y-%m-%d")));
+        
+        let mut day_data = if file_path.exists() {
+            let content = fs::read_to_string(&file_path)
+                .map_err(|e| format!("Failed to read day file: {}", e))?;
+            serde_json::from_str(&content)
+                .map_err(|e| format!("Failed to parse day data: {}", e))?
+        } else {
+            DayData {
+                date,
+                todos: Vec::new(),
+                notes: String::new(),
+            }
+        };
+        
+        // Add each event as a todo at the beginning (in reverse order to preserve event order)
+        for event_text in event_list.iter().rev() {
+            let todo = TodoItem {
+                id: Uuid::new_v4().to_string(),
+                text: event_text.clone(),
+                completed: false,
+                created_at: Local::now(),
+                move_to_next_day: false,
+                notes: String::new(),
+            };
+            day_data.todos.insert(0, todo);
+            migrated_count += 1;
+        }
+        
+        // Save updated day data
+        let json_content = serde_json::to_string_pretty(&day_data)
+            .map_err(|e| format!("Failed to serialize day data: {}", e))?;
+        
+        fs::write(&file_path, json_content)
+            .map_err(|e| format!("Failed to write day file: {}", e))?;
+        
+        migrated_dates.push(date_str);
+    }
+    
+    // Backup original file
+    let backup_file = PathBuf::from(&data_dir).join("calendar_events.json.backup");
+    fs::rename(&events_file, &backup_file)
+        .map_err(|e| format!("Failed to backup calendar events file: {}", e))?;
+    
+    Ok(format!(
+        "Successfully migrated {} calendar events from {} days to todos. Backup saved as calendar_events.json.backup",
+        migrated_count,
+        migrated_dates.len()
+    ))
+}
+
 /// Save user's dark mode preference.
 ///
 /// # Arguments
@@ -463,6 +576,7 @@ fn main() {
                 send_notification,
                 save_calendar_events,
                 load_calendar_events,
+                migrate_calendar_events_to_todos,
                 save_dark_mode_preference,
                 load_dark_mode_preference,
                 save_zoom_preference,
@@ -780,6 +894,142 @@ mod tests {
         assert_eq!(final_events.len(), 2);
         assert!(final_events.contains_key("2024-01-15"));
         assert!(final_events.contains_key("2024-01-16"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_calendar_events_no_file() {
+        let temp_dir = setup_test_dir();
+        let data_dir = temp_dir.path().to_string_lossy().to_string();
+        
+        // No calendar_events.json file exists
+        let result = migrate_calendar_events_to_todos(data_dir).await;
+        
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("migration not needed"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_calendar_events_empty_file() {
+        let temp_dir = setup_test_dir();
+        let data_dir = temp_dir.path().to_string_lossy().to_string();
+        
+        // Create empty calendar events file
+        let empty_events: HashMap<String, Vec<String>> = HashMap::new();
+        save_calendar_events(empty_events, data_dir.clone()).await.unwrap();
+        
+        // Run migration
+        let result = migrate_calendar_events_to_todos(data_dir.clone()).await;
+        
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("empty"));
+        
+        // Verify backup was created
+        let backup_path = temp_dir.path().join("calendar_events.json.backup");
+        assert!(backup_path.exists());
+        
+        // Verify original was removed
+        let original_path = temp_dir.path().join("calendar_events.json");
+        assert!(!original_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_migrate_calendar_events_to_new_todos() {
+        let temp_dir = setup_test_dir();
+        let data_dir = temp_dir.path().to_string_lossy().to_string();
+        
+        // Create calendar events
+        let mut events = HashMap::new();
+        events.insert("2024-01-15".to_string(), vec![
+            "Meeting at 2pm".to_string(),
+            "Call dentist".to_string(),
+        ]);
+        events.insert("2024-01-16".to_string(), vec![
+            "Submit report".to_string(),
+        ]);
+        
+        save_calendar_events(events, data_dir.clone()).await.unwrap();
+        
+        // Run migration
+        let result = migrate_calendar_events_to_todos(data_dir.clone()).await;
+        
+        assert!(result.is_ok());
+        let message = result.unwrap();
+        assert!(message.contains("3 calendar events")); // Total events
+        assert!(message.contains("2 days")); // Number of days
+        
+        // Verify todos were created for 2024-01-15
+        let day_data = load_day_data("2024-01-15".to_string(), data_dir.clone()).await.unwrap();
+        assert_eq!(day_data.todos.len(), 2);
+        assert_eq!(day_data.todos[0].text, "Meeting at 2pm");
+        assert_eq!(day_data.todos[1].text, "Call dentist");
+        assert!(!day_data.todos[0].completed);
+        assert!(!day_data.todos[1].completed);
+        
+        // Verify todos were created for 2024-01-16
+        let day_data2 = load_day_data("2024-01-16".to_string(), data_dir.clone()).await.unwrap();
+        assert_eq!(day_data2.todos.len(), 1);
+        assert_eq!(day_data2.todos[0].text, "Submit report");
+        
+        // Verify backup was created
+        let backup_path = temp_dir.path().join("calendar_events.json.backup");
+        assert!(backup_path.exists());
+        
+        // Verify original was removed
+        let original_path = temp_dir.path().join("calendar_events.json");
+        assert!(!original_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_migrate_calendar_events_merge_with_existing_todos() {
+        let temp_dir = setup_test_dir();
+        let data_dir = temp_dir.path().to_string_lossy().to_string();
+        
+        // Create existing todo for 2024-01-15
+        let existing_day = DayData {
+            date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            todos: vec![
+                TodoItem {
+                    id: Uuid::new_v4().to_string(),
+                    text: "Existing todo".to_string(),
+                    completed: true,
+                    created_at: Local::now(),
+                    move_to_next_day: false,
+                    notes: String::new(),
+                }
+            ],
+            notes: "Existing notes".to_string(),
+        };
+        
+        save_day_data(existing_day, data_dir.clone()).await.unwrap();
+        
+        // Create calendar events
+        let mut events = HashMap::new();
+        events.insert("2024-01-15".to_string(), vec![
+            "Calendar event 1".to_string(),
+            "Calendar event 2".to_string(),
+        ]);
+        
+        save_calendar_events(events, data_dir.clone()).await.unwrap();
+        
+        // Run migration
+        let result = migrate_calendar_events_to_todos(data_dir.clone()).await;
+        
+        assert!(result.is_ok());
+        
+        // Verify todos were merged (calendar events prepended)
+        let day_data = load_day_data("2024-01-15".to_string(), data_dir.clone()).await.unwrap();
+        assert_eq!(day_data.todos.len(), 3);
+        
+        // Calendar events should be first (prepended)
+        assert_eq!(day_data.todos[0].text, "Calendar event 1");
+        assert_eq!(day_data.todos[1].text, "Calendar event 2");
+        
+        // Existing todo should be last
+        assert_eq!(day_data.todos[2].text, "Existing todo");
+        assert!(day_data.todos[2].completed); // Preserved completion status
+        
+        // Existing notes should be preserved
+        assert_eq!(day_data.notes, "Existing notes");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Todo Notes Tracker",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "identifier": "com.todonotestracker",
   "build": {
     "frontendDist": "../ui"

--- a/ui/main.js
+++ b/ui/main.js
@@ -141,7 +141,7 @@ async function initApp() {
             });
         } catch (error) {
             // Migration failure is non-fatal, app continues normally
-            // Error details are logged in backend
+            console.error('Calendar event migration failed:', error);
         }
         
         // Load dark mode preference BEFORE setting up event listeners to avoid race condition
@@ -1058,11 +1058,6 @@ function createCalendarDay(date, today, todayStr, currentDateStr) {
         e.stopPropagation();
     });
     dayEl.appendChild(todoInput);
-    
-    // Events container (kept for styling compatibility, but no longer used for events)
-    const eventsContainer = document.createElement('div');
-    eventsContainer.className = 'calendar-events';
-    dayEl.appendChild(eventsContainer);
     
     // Add todo count badge if there are todos for this day
     const todoCount = calendarTodoCounts[dateStr];

--- a/ui/main.js
+++ b/ui/main.js
@@ -325,14 +325,16 @@ async function saveDayData() {
             dataDir: dataDir
         });
         
-        // Update calendar todo counts for the current day
+        // Update calendar todo counts for the current day only if changed
         const dateStr = formatDate(currentDate);
         const total = currentDayData.todos ? currentDayData.todos.length : 0;
         const completed = currentDayData.todos ? currentDayData.todos.filter(todo => todo.completed).length : 0;
-        calendarTodoCounts[dateStr] = { total, completed };
-        
-        // Refresh calendar display to show updated badge
-        await updateCalendar();
+        const prevCounts = calendarTodoCounts[dateStr] || { total: null, completed: null };
+        if (prevCounts.total !== total || prevCounts.completed !== completed) {
+            calendarTodoCounts[dateStr] = { total, completed };
+            // Refresh calendar display to show updated badge
+            await updateCalendar();
+        }
     } catch (error) {
         console.error('Failed to save day data:', error);
     }

--- a/ui/main.js
+++ b/ui/main.js
@@ -1146,7 +1146,7 @@ async function addCalendarTodo(date, todoText) {
         
         // Create the todo item using the backend command
         const newTodo = await window.invoke('create_todo_item', {
-            text: `📅 ${todoText}`
+            text: todoText
         });
         
         dayData.todos.push(newTodo);

--- a/ui/main.js
+++ b/ui/main.js
@@ -136,12 +136,11 @@ async function initApp() {
         
         // Run one-time migration of calendar events to todos
         try {
-            const migrationResult = await window.invoke('migrate_calendar_events_to_todos', {
+            await window.invoke('migrate_calendar_events_to_todos', {
                 dataDir: dataDir
             });
-            console.log('Migration:', migrationResult);
         } catch (error) {
-            console.error('Migration failed (non-fatal):', error);
+            console.error('Migration failed but app will continue to work normally:', error);
             // Don't block app startup if migration fails
         }
         

--- a/ui/main.js
+++ b/ui/main.js
@@ -140,8 +140,8 @@ async function initApp() {
                 dataDir: dataDir
             });
         } catch (error) {
-            console.error('Migration failed but app will continue to work normally:', error);
-            // Don't block app startup if migration fails
+            // Migration failure is non-fatal, app continues normally
+            // Error details are logged in backend
         }
         
         // Load dark mode preference BEFORE setting up event listeners to avoid race condition
@@ -332,7 +332,7 @@ async function saveDayData() {
         calendarTodoCounts[dateStr] = { total, completed };
         
         // Refresh calendar display to show updated badge
-        updateCalendar();
+        await updateCalendar();
     } catch (error) {
         console.error('Failed to save day data:', error);
     }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -961,6 +961,48 @@ body {
     background: rgba(255,255,255,0.3);
 }
 
+/* Todo count badge in calendar */
+.calendar-todo-badge {
+    display: inline-block;
+    padding: 0.125rem 0.25rem;
+    border-radius: 3px;
+    font-size: 0.55rem;
+    font-weight: 600;
+    margin-top: 0.125rem;
+    text-align: center;
+    white-space: nowrap;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+/* Badge color based on completion status */
+.calendar-todo-badge.all-complete {
+    background: #28a745;
+    color: white;
+}
+
+.calendar-todo-badge.partial-complete {
+    background: #4a90e2;
+    color: white;
+}
+
+.calendar-todo-badge.none-complete {
+    background: #6c757d;
+    color: white;
+}
+
+/* Badge on selected day */
+.calendar-day.selected .calendar-todo-badge {
+    background: rgba(255, 255, 255, 0.3);
+    color: white;
+}
+
+.calendar-day.selected .calendar-todo-badge.all-complete,
+.calendar-day.selected .calendar-todo-badge.partial-complete,
+.calendar-day.selected .calendar-todo-badge.none-complete {
+    background: rgba(255, 255, 255, 0.3);
+    color: white;
+}
+
 /* Responsive calendar */
 @media (max-width: 768px) {
     .calendar-pane {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -931,12 +931,6 @@ body {
     font-size: 0.6rem;
 }
 
-.calendar-events {
-    flex: 1;
-    overflow-y: auto;
-    margin-top: 0.25rem;
-}
-
 /* Todo count badge in calendar */
 .calendar-todo-badge {
     display: inline-block;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -937,30 +937,6 @@ body {
     margin-top: 0.25rem;
 }
 
-.calendar-event {
-    background: #28a745;
-    color: white;
-    padding: 0.125rem 0.25rem;
-    border-radius: 3px;
-    font-size: 0.6rem;
-    margin-bottom: 0.125rem;
-    word-break: break-word;
-    cursor: pointer;
-    transition: background-color 0.2s;
-}
-
-.calendar-event:hover {
-    background: #1e7e34;
-}
-
-.calendar-day.selected .calendar-event {
-    background: rgba(255,255,255,0.2);
-}
-
-.calendar-day.selected .calendar-event:hover {
-    background: rgba(255,255,255,0.3);
-}
-
 /* Todo count badge in calendar */
 .calendar-todo-badge {
     display: inline-block;
@@ -1016,10 +992,6 @@ body {
     
     .calendar-event-input {
         font-size: 0.6rem;
-    }
-    
-    .calendar-event {
-        font-size: 0.55rem;
     }
 }
 


### PR DESCRIPTION
## Summary
This PR simplifies the calendar interface by removing the separate calendar events feature and displaying todo count badges instead.

## Changes Made
- ✅ **Removed calendar events**: Calendar now only works with todos
- ✅ **Added todo count badges**: Calendar days show the number of todos scheduled
- ✅ **Hidden input by default**: Input box only appears when clicking a day
- ✅ **Auto-migration**: Existing calendar events automatically converted to todos
- ✅ **Removed calendar icon**: No longer needed since all items are todos
- ✅ **Cleaner UI**: Better visibility and readability in calendar view

## Breaking Changes
⚠️ **BREAKING CHANGE**: Calendar events are replaced with todos. The app includes automatic migration to convert existing events to todos on first run.

## Technical Details
- Version bumped to **1.4.0** (minor version for new feature)
- Migration command: `migrate_calendar_events` converts events to todos
- Maintains backward compatibility with automatic data migration
- All tests passing ✅

## Testing
- [x] All Rust unit tests pass
- [x] Manual testing confirmed migration works
- [x] Calendar display shows todo counts correctly
- [x] Input box shows/hides properly on day click
- [x] Todos created from calendar appear in main list

## User Experience
Before: Calendar had separate events that weren't integrated with todos
After: Calendar shows todo count badges, clicking day shows/creates todos in main list

This provides a more unified and streamlined experience!